### PR TITLE
Support for RoundUp truncation

### DIFF
--- a/datemath_test.go
+++ b/datemath_test.go
@@ -19,6 +19,7 @@ func TestParseAndEvaluate(t *testing.T) {
 
 		now      string
 		location *time.Location
+		roundUp  bool
 	}{
 
 		// basic dates
@@ -172,6 +173,13 @@ func TestParseAndEvaluate(t *testing.T) {
 			in:  "now/m",
 			out: "2014-11-18T14:27:00.000Z",
 		},
+		{
+			now:     "2014-11-18T14:27:32.000Z",
+			roundUp: true,
+
+			in:  "now/m",
+			out: "2014-11-18T14:27:59.999Z",
+		},
 
 		// epoch times
 		{
@@ -264,7 +272,7 @@ func TestParseAndEvaluate(t *testing.T) {
 				location = tt.location
 			}
 
-			out, err := datemath.ParseAndEvaluate(tt.in, datemath.WithNow(now), datemath.WithLocation(location), datemath.WithBusinessDayFunc(tt.businessDayFunc))
+			out, err := datemath.ParseAndEvaluate(tt.in, datemath.WithNow(now), datemath.WithLocation(location), datemath.WithBusinessDayFunc(tt.businessDayFunc), datemath.WithRoundUp(tt.roundUp))
 			switch {
 			case err == nil && tt.err != nil:
 				t.Errorf("ParseAndEvaluate(%+v) returned no error, expected error %q", tt.in, tt.err)


### PR DESCRIPTION
While not explicitly listed in the ElasticSearch documentation, in practice there is a mode for rounding time ranges up rather than down available in both Grafana and ElasticSearch (which means `now/d` in `from` is the first millisecond of the range and in `to` it's the last millisecond in the range). This PR introduces support for setting an option that rounding should be done upwards to support that case within the library.

 https://github.com/elastic/elasticsearch/blob/2d3f3cd61ef4b218082609928d6ffc9d20c30ba4/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java#L180